### PR TITLE
Feature/revert to 2 2 (#1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ Google BigQuery support for Spark, SQL, and DataFrames.
 | 0.2.x | 2.x.y | Active development |
 | 0.1.x | 1.x.y | Development halted |
 
-To use the package in a Google [Cloud Dataproc](https://cloud.google.com/dataproc/) cluster:
+Building:
 
-install `org.apache.avro_avro-ipc-1.7.7.jar` to `~/.ivy2/jars`
+```sbt clean assembly```
 
-`spark-shell --packages com.spotify:spark-bigquery_2.10:0.2.2`
+Assembly doesn't like the latest version of Java (currently 11) so set JAVA_HOME to point to Java 8.
 
 To use it in a local SBT console:
 
@@ -50,20 +50,9 @@ val table = sqlContext.bigQueryTable("bigquery-public-data:samples.shakespeare")
 val df = sqlContext.bigQuerySelect(
   "SELECT word, word_count FROM [bigquery-public-data:samples.shakespeare]")
 
-// Save data to a table
+  // Save data to a table
 df.saveAsBigQueryTable("my-project:my_dataset.my_table")
 ```
-
-If you'd like to write nested records to BigQuery, be sure to specify an Avro Namespace.
-BigQuery is unable to load Avro Namespaces with a leading dot (`.nestedColumn`) on nested records.
-
-```scala
-// BigQuery is able to load fields with namespace 'myNamespace.nestedColumn'
-df.saveAsBigQueryTable("my-project:my_dataset.my_table", tmpWriteOptions = Map("recordNamespace" -> "myNamespace"))
-```
-See also
-[Loading Avro Data from Google Cloud Storage](https://cloud.google.com/bigquery/docs/loading-data-cloud-storage-avro)
-for data type mappings and limitations. For example loading arrays of arrays is not supported.
 
 # License
 

--- a/build.sbt
+++ b/build.sbt
@@ -17,22 +17,22 @@
 
 name := "spark-bigquery"
 organization := "com.spotify"
-scalaVersion := "2.12.8"
-crossScalaVersions := Seq("2.10.6", "2.11.11", "2.12.8")
+scalaVersion := "2.11.12"
+crossScalaVersions := Seq("2.10.6", "2.11.12")
 
 spName := "spotify/spark-bigquery"
 sparkVersion := "2.4.0"
-sparkComponents := Seq("core", "sql", "avro")
+sparkComponents := Seq("core", "sql")
 spAppendScalaVersion := true
 spIncludeMaven := true
 
 libraryDependencies ++= Seq(
   "com.databricks" %% "spark-avro" % "4.0.0",
-  "com.google.cloud.bigdataoss" % "bigquery-connector" % "hadoop2-0.13.13"
+  "com.google.cloud.bigdataoss" % "bigquery-connector" % "0.10.2-hadoop2"
     exclude ("com.google.guava", "guava-jdk5"),
   "org.slf4j" % "slf4j-simple" % "1.7.21",
   "joda-time" % "joda-time" % "2.9.3",
-  "org.scalatest" %% "scalatest" % "3.0.7" % "test"
+  "org.scalatest" %% "scalatest" % "2.2.1" % "test"
 )
 
 assemblyMergeStrategy in assembly := {

--- a/src/main/scala/com/spotify/spark/bigquery/BigQueryDataFrame.scala
+++ b/src/main/scala/com/spotify/spark/bigquery/BigQueryDataFrame.scala
@@ -47,16 +47,11 @@ class BigQueryDataFrame(df: DataFrame) {
     */
   def saveAsBigQueryTable(tableRef: TableReference,
                           writeDisposition: WriteDisposition.Value,
-                          createDisposition: CreateDisposition.Value,
-                          tmpWriteOptions: Map[String, String]): Unit = {
+                          createDisposition: CreateDisposition.Value): Unit = {
     val bucket = conf.get(BigQueryConfiguration.GCS_BUCKET_KEY)
     val temp = s"spark-bigquery-${System.currentTimeMillis()}=${Random.nextInt(Int.MaxValue)}"
     val gcsPath = s"gs://$bucket/hadoop/tmp/spark-bigquery/$temp"
-
-    tmpWriteOptions match {
-      case null => df.write.format("avro").save(gcsPath)
-      case _ => df.write.options(tmpWriteOptions).format("avro").save(gcsPath)
-    }
+    df.write.avro(gcsPath)
 
     val fdf = bq.load(gcsPath, tableRef, writeDisposition, createDisposition)
     delete(new Path(gcsPath))
@@ -68,13 +63,11 @@ class BigQueryDataFrame(df: DataFrame) {
     */
   def saveAsBigQueryTable(tableSpec: String,
                           writeDisposition: WriteDisposition.Value = null,
-                          createDisposition: CreateDisposition.Value = null,
-                          tmpWriteOptions: Map[String,String] = null): Unit =
+                          createDisposition: CreateDisposition.Value = null): Unit =
     saveAsBigQueryTable(
       BigQueryStrings.parseTableReference(tableSpec),
       writeDisposition,
-      createDisposition,
-      tmpWriteOptions)
+      createDisposition)
 
   private def delete(path: Path): Unit = {
     val fs = FileSystem.get(path.toUri, conf)


### PR DESCRIPTION
* Updating versions

* Revert "Update README.md"

This reverts commit 55c75ec8c6340d9565f9b23c2a51b9e4338039cb.

* Revert "Added support for Spark 2.4.0 and Scala 2.12. Adjusted code slightly since Databricks Avro library moved into Spark with small syntax changes. (#69)"

This reverts commit ee9136bacab8be0c7fe6714893f8df2319fbd844.

* Revert "Update README.md (#68)"

This reverts commit a2d5a63f681237176529c7a5cde46fcd47c7df70.

* Revert "Create daily partitioned table when necessary (#67)"

This reverts commit f5b48152fa6708108e710783b719ab835a404419.

* Revert "Add maintenance mode notice"

This reverts commit ab8fd9cad7b574d4d56d68c7bbb65dd605666c0e.

* Revert "Enable user to specify write options, hinting about issues with nested records (#59)"

This reverts commit 7f65455a53a7654c04368cec83100d8f780252d3.

* Revert "Configuration parameter for intermediate dataset id (#63)"

This reverts commit a0ecb3f642fa39e2780b3e7bd5f49d3c8d5e1a6d.

* Revert "Make a defensive copy to stop polution of sparkconf (#60)"

This reverts commit ffcd9a65fb85b45c4dfd79efc1b94287aba54773.

* Revert "Support setting query job priority (#54)"

This reverts commit 07e012a37709a238fccdc299f494d49b5ed11813.

* Fixing GoogleCredentials to use supplied file